### PR TITLE
Fix file separator per OS. Tests failing in windows.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,11 +1,11 @@
 plugins {
-	id "com.jfrog.bintray" version "1.0"
+    id "com.jfrog.bintray" version "1.0"
 }
 
 repositories {
-	mavenLocal()
-	jcenter()
-	mavenCentral()
+    mavenLocal()
+    jcenter()
+    mavenCentral()
 }
 
 group = 'com.craigburke.angular'
@@ -14,33 +14,33 @@ version = '2.0.4'
 apply plugin: 'groovy'
 apply plugin: 'maven-publish'
 
-configurations { 
-	provided 
-	testCompile { extendsFrom provided }
+configurations {
+    provided
+    testCompile { extendsFrom provided }
 }
 
 dependencies {
-	compile 'com.bertramlabs.plugins:asset-pipeline-core:2.0.12'
-	provided 'org.codehaus.groovy:groovy-all:2.3.6'
-	compile 'org.mozilla:rhino:1.7R4'
-	
-	compile 'com.googlecode.htmlcompressor:htmlcompressor:1.5.2'
-	testCompile 'org.spockframework:spock-core:0.7-groovy-2.0'
+    compile 'com.bertramlabs.plugins:asset-pipeline-core:2.0.12'
+    provided 'org.codehaus.groovy:groovy-all:2.3.6'
+    compile 'org.mozilla:rhino:1.7R4'
+
+    compile 'com.googlecode.htmlcompressor:htmlcompressor:1.5.2'
+    testCompile 'org.spockframework:spock-core:0.7-groovy-2.0'
 }
 
 sourceSets {
-	main {
-		compileClasspath += configurations.provided
-	}
-} 
+    main {
+        compileClasspath += configurations.provided
+    }
+}
 
 task wrapper(type: Wrapper) {
-	gradleVersion = '2.1'
+    gradleVersion = '2.1'
 }
 
 task sourcesJar(type: Jar) {
-	classifier = 'sources'
-	from sourceSets.main.allSource
+    classifier = 'sources'
+    from sourceSets.main.allSource
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
@@ -52,31 +52,31 @@ bintray {
     user = project.hasProperty('bintrayUsername') ? project.bintrayUsername : ''
     key = project.hasProperty('bintrayApiKey') ? project.bintrayApiKey : ''
     publications = ['maven']
-    
-	pkg {
+
+    pkg {
         repo = 'asset-pipeline'
         userOrg = 'craigburke'
         name = 'angular-template-asset-pipeline'
         licenses = ['Apache-2.0']
     }
-	
+
 }
 
 
 publishing {
-	publications {
-		maven(MavenPublication) {
-			artifactId 'angular-template-asset-pipeline'
-			pom.withXml {
-				asNode().children().last() + {
-					resolveStrategy = Closure.DELEGATE_FIRST
-					name 'angular-template-asset-pipeline'
+    publications {
+        maven(MavenPublication) {
+            artifactId 'angular-template-asset-pipeline'
+            pom.withXml {
+                asNode().children().last() + {
+                    resolveStrategy = Closure.DELEGATE_FIRST
+                    name 'angular-template-asset-pipeline'
                     description 'AngularJS Templates extension for the Asset Pipeline Library.'
-					url 'https://github.com/craigburke/angular-template-asset-pipeline'
-					scm {
-						url 'https://github.com/craigburke/angular-template-asset-pipeline'
-						connection 'scm:https://github.com/craigburke/angular-template-asset-pipeline.git'
-						developerConnection 'scm:https://github.com/craigburke/angular-template-asset-pipeline.git'
+                    url 'https://github.com/craigburke/angular-template-asset-pipeline'
+                    scm {
+                        url 'https://github.com/craigburke/angular-template-asset-pipeline'
+                        connection 'scm:https://github.com/craigburke/angular-template-asset-pipeline.git'
+                        developerConnection 'scm:https://github.com/craigburke/angular-template-asset-pipeline.git'
                     }
                     licenses {
                         license {
@@ -90,15 +90,15 @@ publishing {
                             id 'craigburke'
                             name 'Craig Burke'
                             email 'craig@craigburke.com'
-                        	}
-                    	}
-					}
-			}		
-			from components.java
-			artifact sourcesJar
+                        }
+                    }
+                }
+            }
+            from components.java
+            artifact sourcesJar
             artifact javadocJar
-		}
-	}
+        }
+    }
 }
 
 bintrayUpload.dependsOn build, sourcesJar, javadocJar

--- a/core/src/main/groovy/com/craigburke/angular/HTMLTemplateAssetFile.groovy
+++ b/core/src/main/groovy/com/craigburke/angular/HTMLTemplateAssetFile.groovy
@@ -4,13 +4,13 @@ import asset.pipeline.AbstractAssetFile
 import com.craigburke.angular.HTMLTemplateProcessor
 
 class HTMLTemplateAssetFile extends AbstractAssetFile {
-	static final String contentType = 'application/javascript'
-	static extensions = ['tpl.htm', 'tpl.html']
-	static final String compiledExtension = 'js'
+    static final String contentType = 'application/javascript'
+    static extensions = ['tpl.htm', 'tpl.html']
+    static final String compiledExtension = 'js'
 
-	static processors = [HTMLTemplateProcessor]
+    static processors = [HTMLTemplateProcessor]
 
-	static String directiveForLine(String line) {
-		return null
-	}
+    static String directiveForLine(String line) {
+        return null
+    }
 }

--- a/core/src/main/groovy/com/craigburke/angular/HTMLTemplateProcessor.groovy
+++ b/core/src/main/groovy/com/craigburke/angular/HTMLTemplateProcessor.groovy
@@ -10,23 +10,23 @@ import groovy.transform.CompileStatic
 @CompileStatic
 class HTMLTemplateProcessor {
 
-	HTMLTemplateProcessor(AssetCompiler precompiler) { }
+    HTMLTemplateProcessor(AssetCompiler precompiler) {}
 
-	def process(String input, AssetFile assetFile) {
-		Map config = (Map)AssetPipelineConfigHolder.config?.angular
+    def process(String input, AssetFile assetFile) {
+        Map config = (Map) AssetPipelineConfigHolder.config?.angular
 
-		String templateFolder = config?.templateFolder ?: "templates"
+        String templateFolder = config?.templateFolder ?: "templates"
 
-		String moduleName = getModuleName(assetFile, templateFolder)
+        String moduleName = getModuleName(assetFile, templateFolder)
 
-		boolean includePathInName = config?.containsKey('includePathInName') ? config.includePathInName : false
-		String templateName = getTemplateName(assetFile, templateFolder, includePathInName)
-		
-		boolean compressHtml = config?.containsKey('compressHtml') ? config.compressHtml : true
-		boolean preserveHtmlComments = config?.containsKey('preserveHtmlComments') ? config.preserveHtmlComments : false
-		String content = formatHtml(input.toString(), compressHtml, preserveHtmlComments)
-		
-		getTemplateJs(moduleName, templateName, content)
+        boolean includePathInName = config?.containsKey('includePathInName') ? config.includePathInName : false
+        String templateName = getTemplateName(assetFile, templateFolder, includePathInName)
+
+        boolean compressHtml = config?.containsKey('compressHtml') ? config.compressHtml : true
+        boolean preserveHtmlComments = config?.containsKey('preserveHtmlComments') ? config.preserveHtmlComments : false
+        String content = formatHtml(input.toString(), compressHtml, preserveHtmlComments)
+
+        getTemplateJs(moduleName, templateName, content)
     }
 
 }

--- a/core/src/main/groovy/com/craigburke/angular/TemplateProcessorUtil.groovy
+++ b/core/src/main/groovy/com/craigburke/angular/TemplateProcessorUtil.groovy
@@ -8,76 +8,86 @@ import groovy.transform.CompileStatic
 
 @CompileStatic
 class TemplateProcessorUtil {
-	
-	static String formatHtml(String html, boolean compressHtml, boolean preserveHtmlComments) {
-		html = html.replace("'", "\\'")
-		
-		if (compressHtml) {
-			HtmlCompressor compressor = new HtmlCompressor()
-			
-			if (preserveHtmlComments) {
-				compressor.removeComments = false
-			}
-			
-			html = compressor.compress html
-		}
-		
-		html = html.replaceAll("(\r)?\n", " \\n")
-		html
-	}
-	
-	static List<String> getPathParts(AssetFile file, String templateFolder) {
-		file.path.tokenize(Pattern.quote(File.separator)) - templateFolder - file.name
-	}
+
+    static String formatHtml(String html, boolean compressHtml, boolean preserveHtmlComments) {
+        html = html.replace("'", "\\'")
+
+        if (compressHtml) {
+            HtmlCompressor compressor = new HtmlCompressor()
+
+            if (preserveHtmlComments) {
+                compressor.removeComments = false
+            }
+
+            html = compressor.compress html
+        }
+
+        html = html.replaceAll("(\r)?\n", " \\n")
+        html
+    }
+
+    static List<String> getTokenizeFilePath(AssetFile file) {
+        file.path ? file.path.tokenize(Pattern.quote(File.separator)) : []
+    }
+
+    static String getFileNameFromPath(AssetFile file) {
+        List<String> allPartsOfFile = getTokenizeFilePath file
+        allPartsOfFile ? allPartsOfFile[-1] : ''
+    }
+
+    static List<String> getPathParts(AssetFile file, String templateFolder) {
+        List<String> allPartsOfFile = getTokenizeFilePath file
+        String actualFileName = allPartsOfFile ? allPartsOfFile[-1] : ''
+
+        allPartsOfFile - templateFolder - actualFileName
+    }
 
 
-	static String getTemplateName(AssetFile file, String templateFolder, boolean includePath) {
-		String fileName = file.name.replace('.tpl', '')
-		
-		if (includePath) {
-			def pathParts = getPathParts(file, templateFolder)
-			return "/${pathParts.join(File.separator)}/${fileName}" 
-		}
-		else {
-			return fileName
-		}
-	}
-	
-	static String getModuleName(AssetFile file, String templateFolder) {
-		getPathParts(file, templateFolder).collect { String pathPart -> toCamelCase pathPart }.join('.')
-	}
+    static String getTemplateName(AssetFile file, String templateFolder, boolean includePath) {
+        String fileName = getFileNameFromPath(file).replace('.tpl', '')
 
-	static String getTemplateJs(String moduleName, String templateName, String content) {
-		"""\
+        if (includePath) {
+            def pathParts = getPathParts(file, templateFolder)
+            return "$File.separator${pathParts.join(File.separator)}$File.separator${fileName}"
+        } else {
+            return fileName
+        }
+    }
+
+    static String getModuleName(AssetFile file, String templateFolder) {
+        getPathParts(file, templateFolder).collect { String pathPart -> toCamelCase pathPart }.join('.')
+    }
+
+    static String getTemplateJs(String moduleName, String templateName, String content) {
+        """\
 			angular.module('${moduleName}').run(['\$templateCache', function(\$templateCache) {
 				\$templateCache.put('${templateName}', '${content}');
 			}]);
 		""".stripIndent()
-	}
-	
-	static String toCamelCase(String input) {
-		input = input?.toLowerCase()
-		
-		final String separator = "-"
-		
-		if (input?.contains('_')) {
-			input = input.replace('_', separator)
-		}
-		
-		if (!input || !input.contains(separator)) {
-			return input
-		}
-		
-		def result = new StringBuilder()
-		input.split(Pattern.quote(separator)).eachWithIndex { String part, int index ->
-			if (index > 0 && part?.length() != 0) {
-				result.append(part.substring(0, 1).toUpperCase() + part.substring(1))
-			}
-			else {
-				result.append(part ?: "")
-			}
-		}
-		
-		result.toString()
-	}
+    }
+
+    static String toCamelCase(String input) {
+        input = input?.toLowerCase()
+
+        final String separator = "-"
+
+        if (input?.contains('_')) {
+            input = input.replace('_', separator)
+        }
+
+        if (!input || !input.contains(separator)) {
+            return input
+        }
+
+        def result = new StringBuilder()
+        input.split(Pattern.quote(separator)).eachWithIndex { String part, int index ->
+            if (index > 0 && part?.length() != 0) {
+                result.append(part.substring(0, 1).toUpperCase() + part.substring(1))
+            } else {
+                result.append(part ?: "")
+            }
+        }
+
+        result.toString()
+    }
 }

--- a/core/src/test/groovy/com/craigburke/angular/HTMLTemplateProcessorSpec.groovy
+++ b/core/src/test/groovy/com/craigburke/angular/HTMLTemplateProcessorSpec.groovy
@@ -9,7 +9,8 @@ import spock.lang.Unroll
 
 class HtmlTemplateProcessorUnitSpec extends Specification {
 
-    @Shared AssetFile assetFile
+    @Shared
+    AssetFile assetFile
 
     def setup() {
         assetFile = new GenericAssetFile(path: 'foo/bar')

--- a/core/src/test/groovy/com/craigburke/angular/TemplateProcessorUtilSpec.groovy
+++ b/core/src/test/groovy/com/craigburke/angular/TemplateProcessorUtilSpec.groovy
@@ -2,60 +2,58 @@ package com.craigburke.angular
 
 import asset.pipeline.AssetFile
 import asset.pipeline.GenericAssetFile
-
 import spock.lang.Specification
 import spock.lang.Unroll
 import spock.lang.Shared
 
+@Unroll
 class TemplateProcessorUtilUnitSpec extends Specification {
+    @Shared
+            slash = File.separator
 
-    @Unroll("covert string: #input to camel case")
-    def "convert string to camel case"() {
+    def "covert string: #input to camel case"() {
         expect:
         TemplateProcessorUtil.toCamelCase(input) == result
 
         where:
-        input                           || result
-        'foo-bar'                       || 'fooBar'
-        'FOO-bar'                       || 'fooBar'
-        'FOO_BAR'                       || 'fooBar'
-        'why_WOULD-ANyoNE_do-THIS'      || 'whyWouldAnyoneDoThis'
+        input                      || result
+        'foo-bar'                  || 'fooBar'
+        'FOO-bar'                  || 'fooBar'
+        'FOO_BAR'                  || 'fooBar'
+        'why_WOULD-ANyoNE_do-THIS' || 'whyWouldAnyoneDoThis'
     }
 
-    @Unroll("covert path: #path to module name")
-    def "convert path to module name"() {
-		given:
-		AssetFile assetFile = new GenericAssetFile(path: path)
-		
+    def "covert path: #path to module name"() {
+        given:
+        AssetFile assetFile = new GenericAssetFile(path: path)
+
         expect:
         TemplateProcessorUtil.getModuleName(assetFile, 'templates') == result
 
         where:
-        path															|| result
-        'my-app/templates/foo.tpl.html'									|| 'myApp'
-        'my-APP/templates/foo.tpl.html'									|| 'myApp'
-        'my-app/super-COOL-directives/templates/foo.tpl.html'			|| 'myApp.superCoolDirectives'
-        'foo-bar1/foo-bAR2/foo-bAr3/FOO-bar4/templates/foo.tpl.html'	|| 'fooBar1.fooBar2.fooBar3.fooBar4'
+        path                                                                                      || result
+        "my-app${slash}templates${slash}foo.tpl.html"                                             || 'myApp'
+        "my-APP${slash}templates${slash}foo.tpl.html"                                             || 'myApp'
+        "my-app${slash}super-COOL-directives${slash}templates${slash}foo.tpl.html"                || 'myApp.superCoolDirectives'
+        ['foo-bar1', 'foo-bAR2', 'foo-bAr3', 'FOO-bar4', 'templates', 'foo.tpl.html'].join(slash) || 'fooBar1.fooBar2.fooBar3.fooBar4'
     }
 
-   @Unroll("covert path: #path to template name #withPathDescription")
-    def "convert path to module name"() {
-		given:
-		AssetFile assetFile = new GenericAssetFile(path: path)
-		
+    def "covert path: #path to template name #withPathDescription"() {
+        given:
+        AssetFile assetFile = new GenericAssetFile(path: path)
+
         expect:
         TemplateProcessorUtil.getTemplateName(assetFile, 'templates', withPath) == result
-		
-        where:
-        path															| withPath 		|| result			
-        'my-app/templates/foo.tpl.html'                 				| false			|| 'foo.html'
-        'my-app/templates/foo.tpl.html'                 				| true			|| '/my-app/foo.html'
-        'my-app/super-cool-directives/templates/directive.tpl.html' 	| false			|| 'directive.html'
-		'my-app/super-cool-directives/directive.html'					| true			|| '/my-app/super-cool-directives/directive.html'
-        'foo-bar1/foo-bar2/foo-bar3/foo-bar4/templates/foobar.tpl.html'	| false			|| 'foobar.html'	
-		'foo-bar1/foo-bar2/foo-bar3/foo-bar4/foobar.html'				| true			|| '/foo-bar1/foo-bar2/foo-bar3/foo-bar4/foobar.html'
-    
-		withPathDescription = withPath ? 'with path' : 'without path'
-	}
 
+        where:
+        path                                                                                               | withPath || result
+        "my-app${slash}templates${slash}foo.tpl.html"                                                      | false    || 'foo.html'
+        "my-app${slash}templates${slash}foo.tpl.html"                                                      | true     || "${slash}my-app${slash}foo.html"
+        "my-app${slash}super-cool-directives${slash}templates${slash}directive.tpl.html"                   | false    || "directive.html"
+        "my-app${slash}super-cool-directives${slash}directive.html"                                        | true     || "${slash}my-app${slash}super-cool-directives${slash}directive.html"
+        "foo-bar1${slash}foo-bar2${slash}foo-bar3${slash}foo-bar4${slash}templates${slash}foobar.tpl.html" | false    || "foobar.html"
+        "foo-bar1${slash}foo-bar2${slash}foo-bar3${slash}foo-bar4${slash}foobar.html"                      | true     || "${slash}foo-bar1${slash}foo-bar2${slash}foo-bar3${slash}foo-bar4${slash}foobar.html"
+
+        withPathDescription = withPath ? 'with path' : 'without path'
+    }
 }


### PR DESCRIPTION
- Use of `File.separator` in specs. (Note changes to `TemplateProcessorUtilUnitSpec` and `TemplateProcessorUtil`)
- Use of `file.name` from `AssetFile` is hard coded to use `/` instead of `File.separator` which differs per OS.
- Formatted code. 
