### PR TITLE
New config Option includeSectionInModuleName

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -115,6 +115,23 @@ angular.module('myApp.appSection').run(['$templateCache', function($templateCach
 ----
 WARNING: it's important to make sure you file name are unique to avoid collisions 
 
+==== includeSectionInModuleName
+If you want to add all the templates to your base app, you can change the **includeSectionInModuleName.**
+
+With the setting set to false, a file located at
+`/assets/javascripts/my-app/app-section/templates/index.tpl.htm`
+and
+`moduleNameBase = 'myApp'`
+
+Will then generate javascript like this:
+
+[source,javascript]
+----
+angular.module('myApp').run(['$templateCache', function($templateCache) {
+	$templateCache.put('index.htm', '<h1>Hello World!</h1>');
+}]);
+----
+
 In addition to those settings, you can also change the template folder, disable the compression of your HTML templates, or preserve Html comments.
 
 === Gradle

--- a/core/src/main/groovy/com/craigburke/angular/HTMLTemplateProcessor.groovy
+++ b/core/src/main/groovy/com/craigburke/angular/HTMLTemplateProcessor.groovy
@@ -13,11 +13,12 @@ class HTMLTemplateProcessor {
     HTMLTemplateProcessor(AssetCompiler precompiler) {}
 
     def process(String input, AssetFile assetFile) {
-        Map config = (Map)AssetPipelineConfigHolder.config?.angular ?: [:]
+        Map config = (Map) AssetPipelineConfigHolder.config?.angular ?: [:]
 
         String templateFolder = config.containsKey('templateFolder') ? config.templateFolder : 'templates'
         String moduleNameBase = config.containsKey('moduleNameBase') ? config.moduleNameBase : ''
-        String moduleName = getModuleName(assetFile, moduleNameBase, templateFolder)
+        Boolean includeSectionInModuleName = config.containsKey('includeSectionInModuleName') ? config.includeSectionInModuleName : true
+        String moduleName = getModuleName(assetFile, moduleNameBase, templateFolder, includeSectionInModuleName)
 
         boolean includePathInName = config.containsKey('includePathInName') ? config.includePathInName : true
         String templateName = getTemplateName(assetFile, templateFolder, includePathInName)

--- a/core/src/main/groovy/com/craigburke/angular/TemplateProcessorUtil.groovy
+++ b/core/src/main/groovy/com/craigburke/angular/TemplateProcessorUtil.groovy
@@ -47,9 +47,13 @@ class TemplateProcessorUtil {
         }
     }
 
-    static String getModuleName(AssetFile file, String nameBase, String templateFolder) {
-        String name = getPathParts(file, templateFolder).collect { String pathPart -> toCamelCase pathPart }.join('.')
-        (nameBase ?: '') + (nameBase && name ? '.' : '') + name
+    static String getModuleName(AssetFile file, String nameBase, String templateFolder, Boolean includeSectionInModuleName) {
+        if(includeSectionInModuleName){
+            String name = getPathParts(file, templateFolder).collect { String pathPart -> toCamelCase pathPart }.join('.')
+            (nameBase ?: '') + (nameBase && name ? '.' : '') + name
+        }else{
+            nameBase
+        }
     }
 
     static String getTemplateJs(String moduleName, String templateName, String content) {

--- a/core/src/test/groovy/com/craigburke/angular/TemplateProcessorUtilSpec.groovy
+++ b/core/src/test/groovy/com/craigburke/angular/TemplateProcessorUtilSpec.groovy
@@ -26,30 +26,38 @@ class TemplateProcessorUtilUnitSpec extends Specification {
         AssetFile assetFile = new GenericAssetFile(path: path)
 
         expect:
-        TemplateProcessorUtil.getModuleName(assetFile, '', 'templates') == result
+        TemplateProcessorUtil.getModuleName(assetFile, '', 'templates', includeSectionInModuleName) == result
 
         where:
-        path                                                            || result
-        "my-app/templates/foo.tpl.html"                                 || 'myApp'
-        "my-APP/templates/foo.tpl.html"                                 || 'myApp'
-        "my-app/super-COOL-directives/templates/foo.tpl.html"           || 'myApp.superCoolDirectives'
-        "foo-bar1/foo-bAR2/foo-bAr3/FOO-bar4/templates/foo.tpl.html"    || 'fooBar1.fooBar2.fooBar3.fooBar4'
+        path                                                         | includeSectionInModuleName || result
+        "my-app/templates/foo.tpl.html"                              | true                       || 'myApp'
+        "my-APP/templates/foo.tpl.html"                              | true                       || 'myApp'
+        "my-app/super-COOL-directives/templates/foo.tpl.html"        | true                       || 'myApp.superCoolDirectives'
+        "foo-bar1/foo-bAR2/foo-bAr3/FOO-bar4/templates/foo.tpl.html" | true                       || 'fooBar1.fooBar2.fooBar3.fooBar4'
+        "my-app/templates/foo.tpl.html"                              | false                      || ''
+        "my-APP/templates/foo.tpl.html"                              | false                      || ''
+        "my-app/super-COOL-directives/templates/foo.tpl.html"        | false                      || ''
+        "foo-bar1/foo-bAR2/foo-bAr3/FOO-bar4/templates/foo.tpl.html" | false                      || ''
     }
-    
+
     def "module name with moduleBaseName set to #baseName"() {
         given:
         AssetFile assetFile = new GenericAssetFile(path: path)
 
         expect:
-        TemplateProcessorUtil.getModuleName(assetFile, baseName, 'templates') == result
+        TemplateProcessorUtil.getModuleName(assetFile, baseName, 'templates', includeSectionInModuleName) == result
 
         where:
-        path                                                            | baseName   || result
-        "templates/foo.tpl.html"                                        | 'fooApp'   || 'fooApp'
-        "bar/templates/foo.tpl.html"                                    | 'fooApp'   || 'fooApp.bar'
-        "templates/foo.tpl.html"                                        | ''         || ''
-        "bar/templates/foo.tpl.html"                                    | ''         || 'bar'
-        
+        path                         | baseName | includeSectionInModuleName || result
+        "templates/foo.tpl.html"     | 'fooApp' | true                       || 'fooApp'
+        "bar/templates/foo.tpl.html" | 'fooApp' | true                       || 'fooApp.bar'
+        "templates/foo.tpl.html"     | ''       | true                       || ''
+        "bar/templates/foo.tpl.html" | ''       | true                       || 'bar'
+        "templates/foo.tpl.html"     | 'fooApp' | false                      || 'fooApp'
+        "bar/templates/foo.tpl.html" | 'fooApp' | false                      || 'fooApp'
+        "templates/foo.tpl.html"     | ''       | false                      || ''
+        "bar/templates/foo.tpl.html" | ''       | false                      || ''
+
     }
 
     def "covert path: #path to template name #withPathDescription"() {


### PR DESCRIPTION
Current implementation forces creating angular sub modules for each section and then work on the sub modules, which is not that much flexible. I mean modularization has its own advantages, and I agree that it should be used, but still a config option would be great.

I have added a config option `includeSectionInModuleName` that can be set to false and the sub modules won't be created.

eg.

File at "templates/product/index.html" with base app "myapp" currently generates following

```

angular.module('myapp.product').run(['$templateCache', function($templateCache) {}])

```

But with includeSectionInModuleName = false following will be generated

```

angular.module('myapp').run(['$templateCache', function($templateCache) {}])

```

The PR adds
1. Logic to handle this
2. Test cases
3. Documentation updates
